### PR TITLE
Fixed an error with resource paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>test</groupId>
   <artifactId>utils</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
 
   <name>utils</name>
   <description>Test utils</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>test</groupId>
   <artifactId>utils</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.1</version>
 
   <name>utils</name>
   <description>Test utils</description>

--- a/src/main/java/test/Sandbox.java
+++ b/src/main/java/test/Sandbox.java
@@ -139,6 +139,11 @@ public class Sandbox {
         return copyResource(resourcePath, null);
     }
 
+    // Makes it sure a string used to find a resource in the classpath starts with '/'
+    private String validateClasspathPath(String path) {
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
     /**
      * Copies bit to bit some resource from the classpath into the sandboxed directory
      * @param resourcePath Valid classloader path to an existing resource in the classpath (e.g., something in the
@@ -151,7 +156,7 @@ public class Sandbox {
         File toFile = new File(sandbox, newPath != null ? extractPath(newPath) : extractPath(resourcePath));
         assertFalse(toFile.exists());
         if (!toFile.getParentFile().equals(sandbox)) toFile.getParentFile().mkdirs();
-        try (var is = Sandbox.class.getResourceAsStream(resourcePath)) {
+        try (var is = Sandbox.class.getResourceAsStream(validateClasspathPath(resourcePath))) {
             assertNotNull(is);
             Files.copy(is, toFile.toPath());
         } catch (IOException ioe) { fail(ioe); }

--- a/src/test/java/test/TestResources.java
+++ b/src/test/java/test/TestResources.java
@@ -22,6 +22,16 @@ public class TestResources {
     }
 
     @Test
+    public void testCopyResourceWithoutSlash() {
+        var sb = sandbox();
+        sb.runTest((File sandbox) -> {
+            var resource = sb.copyResource("testResource.txt");
+            assertEquals(sandbox, resource.getParentFile());
+            assertEquals("testResource", Files.readString(resource.toPath()));
+        });
+    }
+
+    @Test
     public void testCopyResourcesWithHierarchy() {
         var sb = sandbox();
         sb.runTest((File sandbox) -> {


### PR DESCRIPTION
Fix an error reproducible when using the single parameter version of `copyResource` like in

```
var sb = sandbox();
        sb.runTest((File sandbox) -> {
            // v1 - tester - test - 2024
            var song1 = sb.copyResource("mp3/recording_tags_1.mp3");
```